### PR TITLE
Fix xkb_keymap_num_levels_for_key()

### DIFF
--- a/src/xkb/ffi.rs
+++ b/src/xkb/ffi.rs
@@ -267,7 +267,8 @@ extern {
             -> xkb_layout_index_t;
 
     pub fn xkb_keymap_num_levels_for_key(keymap: *mut xkb_keymap,
-                                         key: xkb_keycode_t)
+                                         key: xkb_keycode_t,
+                                         layout: xkb_layout_index_t)
             -> xkb_level_index_t;
 
     pub fn xkb_keymap_key_get_syms_by_level(keymap: *mut xkb_keymap,

--- a/src/xkb/mod.rs
+++ b/src/xkb/mod.rs
@@ -952,9 +952,9 @@ impl Keymap {
     /// If layout is out of range for this key (that is, larger or equal to
     /// the value returned by num_layouts_for_key()), it is brought
     /// back into range in a manner consistent with State::key_get_layout().
-    pub fn num_levels_for_key(&self, key: Keycode) -> LevelIndex {
+    pub fn num_levels_for_key(&self, key: Keycode, layout: LayoutIndex) -> LevelIndex {
         unsafe {
-            xkb_keymap_num_levels_for_key(self.ptr, key)
+            xkb_keymap_num_levels_for_key(self.ptr, key, layout)
         }
     }
 


### PR DESCRIPTION
Add missing 'layout' parameter to xkb_keymap_num_levels_for_key() and fix Keymap::num_levels_for_key() acordingly.