### PR TITLE
Bumped the version of xcb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 [dependencies]
 libc = "0.2"
 log = "0.3"
-xcb = { version = "0.7", features = ["xkb"], optional=true }
+xcb = { version = "0.8", features = ["xkb"], optional=true }
 
 [features]
 x11 = ["xcb"]


### PR DESCRIPTION
Was getting weird errors using XCB with xkb::x11::setup_xkb_extension() where xkb didn't recognize my xcb::Connection as the correct xcb::base::Connection. Bumping the version fixed this