### PR TITLE
Add new_from_fd as a Context constructor.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ license = "MIT"
 [dependencies]
 libc = "0.2"
 log = "0.3"
+memmap = { version = "0.7", optional=true }
 xcb = { version = "0.8", features = ["xkb"], optional=true }
 
 [features]
 x11 = ["xcb"]
+wayland = ["memmap"]
 compose = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,7 @@
 extern crate libc;
 #[cfg(feature = "x11")]
 extern crate xcb;
+#[cfg(feature = "wayland")]
+extern crate memmap;
 
 pub mod xkb;


### PR DESCRIPTION
Hi,

This adds a `wayland` feature to match the `x11` one. When `wayland` is enabled it adds `mmap` to the dependencies and takes a fd like one would receive from a compositor.